### PR TITLE
Add a script to crop a vertical image into smaller ones with a given ratio

### DIFF
--- a/Autocropping/crop.py
+++ b/Autocropping/crop.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import subprocess
+import argparse
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
+
+parser = argparse.ArgumentParser(
+    description="Crop a verticlal image into smaller ones with a given ratio."
+)
+parser.add_argument("n", help="number of desktops", type=int)
+parser.add_argument("filename", help="filename of the image")
+parser.add_argument("--ratio", help="your screen ratio, default is 16/9", default="16/9")
+args = vars(parser.parse_args())
+
+n = args["n"]
+filename = args["filename"]
+ratio = eval(args["ratio"])
+
+identify_output = subprocess.check_output(["identify", filename])
+identify_output = identify_output.decode()
+dimensions = identify_output.split()[2]
+x, y = dimensions.split("x")
+x = int(x)
+y = int(y)
+
+overlap = (x / ratio * n - y) / (n - 1)
+overlap = int(overlap)
+
+out_filenames = os.path.join(dir_path, "cropped-%d.png")
+cmd = ["convert", filename, "-crop", f"1x{n}+0+{overlap}@", out_filenames]
+subprocess.check_output(cmd)

--- a/Autocropping/crop.py
+++ b/Autocropping/crop.py
@@ -27,6 +27,6 @@ y = int(y)
 overlap = (x / ratio * n - y) / (n - 1)
 overlap = int(overlap)
 
-out_filenames = os.path.join(dir_path, "cropped-%d.png")
+out_filenames = os.path.join(dir_path, "cropped-%d.jpg")
 cmd = ["convert", filename, "-crop", f"1x{n}+0+{overlap}@", out_filenames]
 subprocess.check_output(cmd)


### PR DESCRIPTION
Then all those images can be composed into a kind of a sliding desktop.

Example:
![Screenshot_20210920_114725](https://user-images.githubusercontent.com/26285707/133983794-b19dc2c2-2290-4bba-bb9e-ac5fcf1ae933.png)
![Screenshot_20210920_114741](https://user-images.githubusercontent.com/26285707/133983749-368d9996-9e90-4b54-b581-0973a83f1cce.png)
![Screenshot_20210920_114752](https://user-images.githubusercontent.com/26285707/133983662-9c590cef-e422-4de5-8fe9-437a8ccd7a18.png)
![Screenshot_20210920_114802](https://user-images.githubusercontent.com/26285707/133983544-414459ad-e9d7-4aa0-9d78-bf3997408558.png)

You can see how to use it with
```
python crop.py -h
```

I was also wondering if there is some way to tell Vallpaper to reload images from the command line, instead of GUI. Then, it could be automated nicely.

Or even better, to tell Vallpaper from the command line to set some image on some desktop.