### PR TITLE
Fix desktop detection when "Switch desktops independently for each screen" is enabled in Plasma 6.7

### DIFF
--- a/Vallpaper/package/contents/js/v.js
+++ b/Vallpaper/package/contents/js/v.js
@@ -250,3 +250,26 @@ const GET_CURRENT_DESKNO = function($VirtualDesktopInfo) {
 
   return idx+1;
 }
+
+const GET_CURRENT_DESKNO_FOR_SCREEN = function($VirtualDesktopInfo, $screenName) {
+
+  if( ! $screenName || typeof $VirtualDesktopInfo.currentDesktopByScreenName !== 'function')
+  { return GET_CURRENT_DESKNO($VirtualDesktopInfo); }
+  //<--
+
+
+  const currentId = $VirtualDesktopInfo.currentDesktopByScreenName($screenName);
+  const ids = $VirtualDesktopInfo.desktopIds;
+
+  let idx = 0;
+
+  for(; idx < ids.length; idx++)
+  {
+    if(ids[idx] == currentId) { break; }
+    //<--
+
+
+  }
+
+  return idx+1;
+}

--- a/Vallpaper/package/contents/ui/config.qml
+++ b/Vallpaper/package/contents/ui/config.qml
@@ -37,7 +37,7 @@ QTQ_L.ColumnLayout { id: _Root
   QTQ.Component.onCompleted: {
 
 /*MOD*/plasmacfgAdapter = new VJS.PlasmacfgAdapter(cfg_vallpaper601, $newCfg => { cfg_vallpaper601 = $newCfg; });
-    selectDesktop__init(VJS.GET_CURRENT_DESKNO(_VirtualDesktopInfo));
+    selectDesktop__init(VJS.GET_CURRENT_DESKNO_FOR_SCREEN(_VirtualDesktopInfo, QTQ.Screen.name));
   }
 
   KDE_taskmanager.VirtualDesktopInfo { id: _VirtualDesktopInfo }

--- a/Vallpaper/package/contents/ui/main.qml
+++ b/Vallpaper/package/contents/ui/main.qml
@@ -28,6 +28,14 @@ import "../js/v.js" as VJS
 
   property var activeImage
   property bool repeaterReady: false
+  property string screenName: {
+    const idx = KDE_plasmoid.Plasmoid.screen;
+    if(idx >= 0 && idx < Qt.application.screens.length)
+    {
+      return Qt.application.screens[idx].name;
+    }
+    return "";
+  }
 
 /*MOD*/contextualActions: [
     KDE_pc.Action {
@@ -69,6 +77,14 @@ import "../js/v.js" as VJS
 
     onCurrentDesktopChanged: broadcastDesktopChanged();
 
+    onCurrentDesktopForScreenChanged: (changedScreenName) => {
+
+      if(screenName === "" || changedScreenName === screenName)
+      {
+        broadcastDesktopChanged();
+      }
+    }
+
     onNumberOfDesktopsChanged: {
 
       broadcastNumberOfDesktopsChanged();
@@ -80,7 +96,7 @@ import "../js/v.js" as VJS
 	    //<--
 
 
-      const newActiveImage = _ImageRepeater.imageFor(VJS.GET_CURRENT_DESKNO(_VirtualDesktopInfo));
+      const newActiveImage = _ImageRepeater.imageFor(VJS.GET_CURRENT_DESKNO_FOR_SCREEN(_VirtualDesktopInfo, screenName));
       newActiveImage.refresh();
       activeImage = newActiveImage;
 	  }


### PR DESCRIPTION
### Context
KDE Plasma 6.7 introduced a new configuration option allowing users to switch virtual desktops independently on each screen (`Window Management` => `Virtual Desktops` => `Switch desktops independently for each screen`).

### The Problem
With this setting enabled, the plugin previously appeared to detect the virtual desktop of the screen under the mouse pointer. This is unexpected behavior, as wallpaper configuration is handled on a per-screen basis regardless of where the cursor is.

### Proposed Solution
This PR adjusts the desktop detection logic to target the specific screen being configured rather than relying on the pointer's location. 

### Implementation & Verification Note
* **AI Assistance:** This patch was created with the assistance of an AI tool. Because I am not deeply familiar with this codebase or Plasma wallpaper plugin development, I am unable to verify the architectural correctness of the changes myself. 
* **Testing:** In my manual testing, these changes successfully resolve the issue. Please review the code closely to ensure there are no unintended side effects.